### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/lib/grpc-api-assistant/version.rb
+++ b/lib/grpc-api-assistant/version.rb
@@ -1,3 +1,3 @@
 module GrpcApiAssistant
-  VERSION = "0.5.0"
+  VERSION = '0.6.0'.freeze
 end


### PR DESCRIPTION
# Description

as part of https://github.com/michaelkeeling/cucumber-grpc-api-assistant/pull/6 we didn't bump the gem version for the new functionality