### PR TITLE
Fix ci warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,28 +6,25 @@ on:
   pull_request:
     branches: [ master ]
 
+# https://github.com/ruby/setup-ruby  
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        ruby: ['3.0', '3.2']
+    
+    runs-on: ${{ matrix.os }}
 
     if: (!contains(github.event.head_commit.message, '[skip ci]')) && (!contains(github.event.head_commit.message, '[ci skip]'))
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
-        uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0.0
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Install dependencies
-        run: bundle install
       - name: Run tests
         run: bundle exec rake test
-      # - name: Run security checks
-      #   run: |
-      #     bin/bundler-audit --update
-      #     bin/brakeman -q -w2
-      # # Add or Replace any other Linters here
-      # - name: Run linters
-      #   run: |
-      #     bin/rubocop --parallel

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,0 +1,1 @@
+default: --publish-quiet


### PR DESCRIPTION
Address CI deprecation warnings.

Following instructions at https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby

appears to need more fiddling, warnings are still present.