### PR TITLE
Add grpc step 'the {string} field in the response object does not have a value'

### DIFF
--- a/features/calculator_testing.feature
+++ b/features/calculator_testing.feature
@@ -34,6 +34,7 @@ Feature: Basic gRPC step functions
     When I call the 'unary_operation' method in the Calculator service
     Then the response object is not an error
     And the 'result' field in the response object has a value
+    And the 'some_missing_field' field in the response object does not have a value
     And the 'result' field in the response object is -6
     And the 'result' field in the response object is not 1234
     And the 'result' field in the response object is the same as the value stored in the key 'saved_value'
@@ -156,7 +157,7 @@ Feature: Basic gRPC step functions
       """
       {
         "timestamp": "2023-10-31T01:03:05Z"
-      }      
+      }
       """
     Then the 'timestamp' field in the response object has a timestamp equal to '2023-10-31T01:03:05Z'
 
@@ -164,9 +165,9 @@ Feature: Basic gRPC step functions
       """
       {
 
-      }      
+      }
       """
-    Then the 'timestamp' field in the response object has a timestamp equal to 'nil'    
+    Then the 'timestamp' field in the response object has a timestamp equal to 'nil'
 
   Scenario: Checking values using field navigation
     Given an 'MultiUnaryRequest' that looks like the following
@@ -187,3 +188,15 @@ Feature: Basic gRPC step functions
     And the 'results/0' field in the response object is '-1'
     And the 'results/0' field in the response object is not '1000'
     And the 'foo' field in the response object is empty
+
+  Scenario: Matcher for checking a list field does not have a value
+    Given an 'MultiUnaryRequest' that looks like the following
+      """
+      {
+        "xs": [],
+        "operand": "+"
+      }
+      """
+    When I call the 'multi_unary_operation' method in the Calculator service
+    Then the response object is not an error
+    And the 'results' field in the response object does not have a value

--- a/lib/grpc-api-assistant/grpc_steps.rb
+++ b/lib/grpc-api-assistant/grpc_steps.rb
@@ -111,6 +111,13 @@ Then 'the {string} field in the response object has a value' do |field_path|
   expect(value.empty?).to be false if value.respond_to?(:empty?)
 end
 
+Then 'the {string} field in the response object does not have a value' do |field_path|
+  expect(@grpc_response).not_to be nil
+  expect(@grpc_response).not_to be_a(GRPC::BadStatus)
+  value = GrpcHelpers::fetch_from_grpc_with_shorthand(field_path, @grpc_response)
+  expect(value.nil? || (value.respond_to?(:empty?) && value.empty?)).to be true
+end
+
 Then 'the {string} field in the response object has {int} value(s)' do |field_path, count|
   expect(@grpc_response).not_to be nil
   value = GrpcHelpers::fetch_from_grpc_with_shorthand(field_path, @grpc_response)


### PR DESCRIPTION
This is the inverse of 'the {string} field in the response object has a value'

### Testing
Ran `rake test`