### PR TITLE
revert gRPC update

### DIFF
--- a/grpc-api-assistant.gemspec
+++ b/grpc-api-assistant.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.2.0'
   spec.license = 'MIT'
 
-  spec.add_dependency('grpc', '~> 1.65')
-  spec.add_dependency('grpc-tools', '~> 1.65')
-  spec.add_dependency('net-ssh', '~> 7.2')
+  spec.add_dependency('grpc', '~> 1.52')
+  spec.add_dependency('grpc-tools', '~> 1.51')
+  spec.add_dependency('net-ssh', '~> 7.0')
 
   spec.add_dependency('cucumber', '~> 9.2')
   spec.add_dependency('rspec-expectations', '~> 3.12')


### PR DESCRIPTION
Latest gRPC seems to run into issues with Wiremock docker containers.  Reverting for now pending more testing.